### PR TITLE
Fix priors aspect ratio

### DIFF
--- a/training_toolbox/ssd_detector/README.md
+++ b/training_toolbox/ssd_detector/README.md
@@ -16,7 +16,7 @@ We provide 2 predefined configuration:
 
 * Object detector trained on the [COCO dataset](../../data/coco/README.md).
   - Configuration file: [training_toolbox/ssd_detector/coco/config.py](coco/config.py).
-  - Trained model: [MobileNet v2 1.0 256x256](https://download.01.org/openvinotoolkit/training_toolbox_tensorflow/models/ssd_detector/coco/0122_ssd_mobilenet_v2_1.0_coco_256x256.zip).
+  - Trained model: [MobileNet v2 1.0 256x256](https://www.myqnapcloud.com/smartshare/6d62i0464l6p7019t3wz2891_62ahvLt).
 
 ### Quck start with vehicles and license plates detector
 

--- a/training_toolbox/ssd_detector/README.md
+++ b/training_toolbox/ssd_detector/README.md
@@ -12,7 +12,7 @@ We provide 2 predefined configuration:
   ![VLP detection](vlp/docs/sample.jpg "Example of VLP detector inference")
 
   - Configuration file: [training_toolbox/ssd_detector/vlp/config.py](vlp/config.py).
-  - Trained model: [MobileNet v2 0.35 256x256](https://download.01.org/openvinotoolkit/training_toolbox_tensorflow/models/ssd_detector/vlp/0123_ssd_mobilenet_v2_0.35_barrier_256x256.zip).
+  - Trained model: [MobileNet v2 0.35 256x256](https://download.01.org/openvinotoolkit/training_toolbox_tensorflow/models/ssd_detector/vlp/0123_ssd_mobilenet_v2_0.35.1_barrier_256x256.zip).
 
 * Object detector trained on the [COCO dataset](../../data/coco/README.md).
   - Configuration file: [training_toolbox/ssd_detector/coco/config.py](coco/config.py).

--- a/training_toolbox/ssd_detector/toolbox/priors.py
+++ b/training_toolbox/ssd_detector/toolbox/priors.py
@@ -39,8 +39,8 @@ def prior_box_specs(blob, image_size, box_specs, step, clip=False, offset=0.5, v
       center_x = (width + offset) * step_x
 
       for size, aspect_ratio in box_specs:
-        box_w = size * aspect_ratio
-        box_h = size / aspect_ratio
+        box_w = size * math.sqrt(aspect_ratio)
+        box_h = size / math.sqrt(aspect_ratio)
         xmin = (center_x - box_w / 2.) / image_size[1]
         ymin = (center_y - box_h / 2.) / image_size[0]
         xmax = (center_x + box_w / 2.) / image_size[1]


### PR DESCRIPTION
* Fix priors aspect ratio for the default priors configuration.
* Update the COCO model - 20 mAP@[.5:.95].
* Fix the broken link to the Barrier model.